### PR TITLE
Calling --cp-jar to create pathing jar

### DIFF
--- a/ClojureTools.psm1
+++ b/ClojureTools.psm1
@@ -22,7 +22,7 @@ function Invoke-Clojure {
   # Set dir containing the installed files
   $InstallDir = $PSScriptRoot
   $Version = '1.10.0.414'
-  $ToolsCp = "$InstallDir\clojure-tools-$Version.jar"
+  $ToolsCp = "$InstallDir\tools.deps.alpha-0.6.497-SNAPSHOT.jar;$InstallDir\clojure-tools-$Version.jar"
 
 
   # Extract opts
@@ -222,6 +222,7 @@ For more info, see:
 
   $LibsFile = "$CacheDir\$CacheKeyHash.libs"
   $CpFile = "$CacheDir\$CacheKeyHash.cp"
+  $CpJarFile = "$CacheDir\$CacheKeyHash.jar"
   $JvmFile = "$CacheDir\$CacheKeyHash.jvm"
   $MainFile = "$CacheDir\$CacheKeyHash.main"
 
@@ -234,6 +235,7 @@ config_dir   = $ConfigDir
 config_paths = $ConfigPaths
 cache_dir    = $CacheDir
 cp_file      = $CpFile
+cp_jar       = $CpJarFile
 "@
   }
 
@@ -277,7 +279,7 @@ cp_file      = $CpFile
     if ($Verbose) {
       Write-Host "Refreshing classpath"
     }
-    & $JavaCmd -Xmx256m -classpath $ToolsCp clojure.main -m clojure.tools.deps.alpha.script.make-classpath --config-files $ConfigStr --libs-file $LibsFile --cp-file $CpFile --jvm-file $JvmFile --main-file $MainFile $ToolsArgs
+    & $JavaCmd -Xmx256m -classpath $ToolsCp clojure.main -m clojure.tools.deps.alpha.script.make-classpath --config-files $ConfigStr --libs-file $LibsFile --cp-file $CpFile --cp-jar $CpJarFile --jvm-file $JvmFile --main-file $MainFile $ToolsArgs
     if ($LastExitCode -ne 0) {
       return
     }
@@ -322,7 +324,12 @@ cp_file      = $CpFile
       # TODO this seems dangerous
       $MainCacheOpts = ((Get-Content $MainFile) -split '\s+') -replace '"', '\"'
     }
-    & $JavaCmd @JvmCacheOpts @JvmOpts "-Dclojure.libfile=$LibsFile" -classpath $CP clojure.main @MainCacheOpts @ClojureArgs
+    if (Test-Path $CpJarFile -and (-not $ForceCP)) {
+      $ExecCP = $CpJarFile
+    } else {
+      $ExecCP = $CP
+    }
+    & $JavaCmd @JvmCacheOpts @JvmOpts "-Dclojure.libfile=$LibsFile" -classpath $ExecCP clojure.main @MainCacheOpts @ClojureArgs
   }
 }
 


### PR DESCRIPTION
Ok, so this is not completely ready to merge yet, but I've tested it locally and it fixes #2 for me there. This needs to work in tandem with the patch to tools.deps.alpha in [TDEPS-120](https://dev.clojure.org/jira/browse/TDEPS-120).

The change is not complex, it just passes an additional `--cp-jar` argument to the make-classpath part of tools.deps.alpha with the same hash location as the existing `.cp` files. Then, if the jar file exists at execution time, we use it as the single `-cp` argument to `java.exe`, instead of the concatenated contents of the file.

How I ran it:

- Applied the tools.deps.alpha patch from TDEPS-120 (also available [at this branch of my fork](https://github.com/timgilbert/tools.deps.alpha/tree/pathing-jar))
- From there, `mvn install -DskipTests` (some TDA tests are failing in Windows)
- cd into the ClojureTools directory (for me I had it checked out in `~/Documents/WindowsPowerShell\Modules`
- `cp C:\src\tools.deps.alpha\target\tools.deps.alpha-0.6.497-SNAPSHOT.jar .`
- `Import-Module ClojureTools -Force`
- In a directory with a large classpath: `clj`, whih launches correctly.

In order to merge this, we'd need the TDEPS-120 patch to be merged into tools.deps.alpha, and a new version of `clojure-tools.jar` to be built from that.